### PR TITLE
Fix code scanning alert no. 7: Full server-side request forgery

### DIFF
--- a/app/parser.py
+++ b/app/parser.py
@@ -13,6 +13,8 @@ logger = logging.getLogger(__name__)
 
 BASE_DIR = os.path.abspath(os.path.join(os.path.dirname(__file__), '../web_archives'))
 
+AUTHORIZED_DOMAINS = ["example.com", "anotherdomain.com"]
+
 def fetch_and_store_page(domain, url, base_url, visited_urls):
     if url in visited_urls:
         logger.debug(f"Skipping already visited URL: {url}")
@@ -20,6 +22,11 @@ def fetch_and_store_page(domain, url, base_url, visited_urls):
 
     visited_urls.add(url)
     
+    parsed_url = urlparse(url)
+    if parsed_url.netloc not in AUTHORIZED_DOMAINS:
+        logger.error(f"Unauthorized domain: {parsed_url.netloc}")
+        return
+
     try:
         response = requests.get(url, timeout=10)
         if response.status_code != 200:


### PR DESCRIPTION
Fixes [https://github.com/Eldritchy/ReturnTime/security/code-scanning/7](https://github.com/Eldritchy/ReturnTime/security/code-scanning/7)

To fix the problem, we need to ensure that the URL used in the `requests.get` call is validated and sanitized properly. One effective way to do this is to maintain a list of authorized domains and ensure that the user-provided URL belongs to one of these domains. This approach prevents the user from directing the request to an unauthorized or malicious server.

1. Create a list of authorized domains.
2. Validate the user-provided URL to ensure it belongs to one of the authorized domains.
3. If the URL is valid, proceed with the request; otherwise, return an error.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
