### PR TITLE
Fix code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/app/web.py
+++ b/app/web.py
@@ -55,7 +55,11 @@ def view_page():
         return jsonify({"error": "Full URL is required"}), 400
 
     sanitized = sanitize_domain_or_url(domain_or_url)
-    domain_db_path = os.path.join(BASE_DIR, f'{sanitized}.db')
+    domain_db_path = os.path.normpath(os.path.join(BASE_DIR, f'{sanitized}.db'))
+
+    if not domain_db_path.startswith(BASE_DIR):
+        logging.error(f"Attempted access to a path outside the base directory: {domain_db_path}")
+        return jsonify({"error": "Invalid path"}), 400
 
     if not os.path.exists(domain_db_path):
         logging.error(f"No database found for URL: {domain_or_url}")


### PR DESCRIPTION
Fixes [https://github.com/Eldritchy/ReturnTime/security/code-scanning/4](https://github.com/Eldritchy/ReturnTime/security/code-scanning/4)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. We will normalize the path using `os.path.normpath` to remove any ".." segments and then check that the normalized path starts with the root folder (`BASE_DIR`). This will prevent any path traversal attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
