### PR TITLE
Fix code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/app/parser.py
+++ b/app/parser.py
@@ -80,7 +80,11 @@ def process_resource(tag, base_url, resource_folder, domain, page_uuid, timestam
         res = requests.get(full_resource_url, timeout=10)
         if res.status_code == 200:
             resource_filename = generate_unique_filename(full_resource_url)
-            resource_path = os.path.join(resource_folder, resource_filename)
+            resource_path = os.path.normpath(os.path.join(resource_folder, resource_filename))
+
+            if not resource_path.startswith(resource_folder):
+                logger.error(f"Invalid resource path: {resource_path}")
+                return
 
             with open(resource_path, 'wb') as file:
                 file.write(res.content)


### PR DESCRIPTION
Fixes [https://github.com/Eldritchy/ReturnTime/security/code-scanning/3](https://github.com/Eldritchy/ReturnTime/security/code-scanning/3)

To fix the problem, we need to ensure that the constructed file path is contained within a safe root folder. We can achieve this by normalizing the path using `os.path.normpath` and then checking that the normalized path starts with the root folder. This will prevent directory traversal attacks and ensure that the file operations are performed within the intended directory.

1. Normalize the `resource_path` using `os.path.normpath`.
2. Check that the normalized `resource_path` starts with the `resource_folder`.
3. Raise an exception or log an error if the check fails.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
