### PR TITLE
Fix code scanning alert no. 2: Uncontrolled data used in path expression

### DIFF
--- a/app/parser.py
+++ b/app/parser.py
@@ -43,7 +43,9 @@ def fetch_and_store_page(domain, url, base_url, visited_urls):
         timestamp = datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
         soup = BeautifulSoup(response.text, 'html.parser')
 
-        resource_folder = os.path.join(BASE_DIR, sanitize_domain(domain), page_uuid)
+        resource_folder = os.path.normpath(os.path.join(BASE_DIR, sanitize_domain(domain), page_uuid))
+        if not resource_folder.startswith(BASE_DIR):
+            raise Exception("Invalid resource folder path")
         os.makedirs(resource_folder, exist_ok=True)
 
         for tag in soup.find_all(['link', 'script', 'img']):


### PR DESCRIPTION
Fixes [https://github.com/Eldritchy/ReturnTime/security/code-scanning/2](https://github.com/Eldritchy/ReturnTime/security/code-scanning/2)

To fix the problem, we need to ensure that the constructed `resource_folder` path is contained within a safe root directory (`BASE_DIR`). This can be achieved by normalizing the path using `os.path.normpath` and then verifying that the normalized path starts with the `BASE_DIR`. This approach will prevent directory traversal attacks by ensuring that the final path is within the intended directory.

1. Normalize the constructed path using `os.path.normpath`.
2. Check that the normalized path starts with `BASE_DIR`.
3. Raise an exception if the path is not within `BASE_DIR`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
